### PR TITLE
Modify to dynamically find all TIA Portal installs (both x86 and x64).

### DIFF
--- a/TiaArmPatcher/TiaArmPatcher/Program.cs
+++ b/TiaArmPatcher/TiaArmPatcher/Program.cs
@@ -1,4 +1,8 @@
-﻿using Mono.Cecil;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
 
@@ -6,180 +10,213 @@ Console.ForegroundColor = ConsoleColor.Gray;
 Console.WriteLine("TIA Portal ARM Patcher");
 Console.WriteLine();
 
+const string TIARootPath = "C:\\Program Files\\Siemens\\Automation";
+const string TIAx86RootPath = "C:\\Program Files (x86)\\Siemens\\Automation";
+bool x86PathExists = false;
+bool nonx86PathExists = false;
+
+List<string> tiaVersions = new();
+if (Directory.Exists(TIAx86RootPath))
+{
+    var range = Directory.GetDirectories(TIAx86RootPath).Where(x => x.Contains("Portal") && Directory.Exists(Path.Combine(x, "bin")));
+    tiaVersions.AddRange(range);
+    x86PathExists = range.Any();
+}
+if (Directory.Exists(TIARootPath))
+{
+    var range = Directory.EnumerateDirectories(TIARootPath).Where(x => x.Contains("Portal") && Directory.Exists(Path.Combine(x, "bin")));
+    tiaVersions.AddRange(range);
+    nonx86PathExists = range.Any();
+}
+
+if (tiaVersions.Count == 0)
+{
+    Console.ForegroundColor = ConsoleColor.Red;
+    Console.WriteLine("No TIA Portal installations found, exiting...");
+    Console.ForegroundColor = ConsoleColor.Gray;
+    return;
+}
+
 Console.WriteLine("Choose the version to patch:");
-Console.WriteLine("1. V17");
-Console.WriteLine("2. V18");
-
-int choice;
-string input = Console.ReadLine();
-bool isValid = int.TryParse(input, out choice) && (choice == 1 || choice == 2);
-
-while (!isValid)
+for(int i = 0; i < tiaVersions.Count; i++)
 {
-    Console.WriteLine("Invalid choice. Please enter 1 or 2.");
-    input = Console.ReadLine();
-    isValid = int.TryParse(input, out choice) && (choice == 1 || choice == 2);
+    Console.WriteLine($"  {i}.\t{tiaVersions[i]}");
 }
-
-string tiaPath;
-
-if (choice == 1)
-{
-    tiaPath = "C:\\Program Files\\Siemens\\Automation\\Portal V17\\Bin";
-}
-else // choice == 2
-{
-    tiaPath = "C:\\Program Files\\Siemens\\Automation\\Portal V18\\Bin";
-}
-
-Console.WriteLine("TIA Dir: " + tiaPath);
 Console.WriteLine();
+if ( x86PathExists && nonx86PathExists )
+{
+    Console.WriteLine($"  x86\tPatch all x86 versions detected");
+    Console.WriteLine($"  x64\tPatch all x64 versions detected");
+}
+Console.WriteLine($"  ALL\tPatch all versions detected");
+Console.WriteLine($"  ?\tDisplay this list again");
+
+int choice = -1;
+bool patchAll = false;
+bool patchx86 = false;
+bool patchx64 = false;
+bool isValid = false;
+
+do
+{
+    var input = Console.ReadLine();
+    patchAll = (input == "ALL");
+    patchx86 = (patchAll || input == "x86");
+    patchx64 = (patchAll || input == "x64");
+
+    bool displayHelp = (input == "?");
+    isValid = (int.TryParse(input, out choice) && (choice < tiaVersions.Count)) || patchAll || patchx86 || patchx64;
+    if (displayHelp)
+    {
+        for (int i = 0; i < tiaVersions.Count; i++)
+        {
+            Console.WriteLine($"{i}\t{tiaVersions[i]}");
+        }
+        Console.WriteLine();
+        if (x86PathExists && nonx86PathExists)
+        {
+            Console.WriteLine($"  x86\tPatch all x86 versions detected");
+            Console.WriteLine($"  x64\tPatch all x64 versions detected");
+        }
+        Console.WriteLine($"ALL\tPatch all versions detected");
+        Console.WriteLine($"?\tDisplay this list again");
+    }
+    else
+    {
+        if (!isValid)
+            Console.WriteLine($"Invalid choice. Please enter a choice between 0 and {tiaVersions.Count - 1}, or ALL for all.");
+    }
+} while (!isValid);
+
+List<string> patchPaths = new();
+if (patchAll)
+    patchPaths.AddRange(tiaVersions.Select(x => Path.Combine(x, "bin")));
+else if (patchx86)
+    patchPaths.AddRange(tiaVersions.Where(x => x.StartsWith(TIAx86RootPath)).Select(x => Path.Combine(x,"bin")));
+else if (patchx64)
+    patchPaths.AddRange(tiaVersions.Where(x => x.StartsWith(TIARootPath)).Select(x => Path.Combine(x, "bin")));
+else
+    patchPaths = new List<string>{ Path.Combine(tiaVersions[choice], "bin") };
+
 
 var patchedFiles = new List<string>();
-
-using (var resolver = new DefaultAssemblyResolver())
+foreach (var tiaPath in patchPaths)
 {
+    Console.WriteLine("TIA Dir: " + tiaPath);
+
+    using var resolver = new DefaultAssemblyResolver();
     resolver.AddSearchDirectory(tiaPath);
     foreach (var file in Directory.GetFiles(tiaPath, "*.dll"))
     {
         try
         {
-            using (var assembly = AssemblyDefinition.ReadAssembly(file, new ReaderParameters { AssemblyResolver = resolver }))
+            using var assembly = AssemblyDefinition.ReadAssembly(file, new ReaderParameters { AssemblyResolver = resolver });
+            var module = assembly.MainModule;
+            bool filePatched = false;
+
+            foreach (var assemblyIteratorType in module.GetTypes().Where(x => x.Name == "AssemblyIterator" || x.Name == "InternalAssemblyIterator"))
             {
-                var module = assembly.MainModule;
-                
-                if (module.GetTypes().Any(x => x.Name == "AssemblyIterator" || x.Name == "InternalAssemblyIterator"))
+                filePatched = true;
+                var method = assemblyIteratorType.GetMethods().First(x => x.Name == "CheckIfSignatureOfSingleAssemblyIsValid");
+
+                method.Body.InitLocals = true;
+                method.Body.Variables.Clear();
+                method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
+                method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
+                method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Byte.MakeArrayType()));
+                method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Boolean));
+
+                var ilProcessor = method.Body.GetILProcessor();
+                ilProcessor.Clear();
+                ilProcessor.Append(Instruction.Create(OpCodes.Nop));
+                ilProcessor.Append(Instruction.Create(OpCodes.Ldc_I4_1));
+                ilProcessor.Append(Instruction.Create(OpCodes.Stloc_3));
+                var i = Instruction.Create(OpCodes.Ldloc_3);
+                ilProcessor.Append(Instruction.Create(OpCodes.Br_S, i));
+                ilProcessor.Append(i);
+                ilProcessor.Append(Instruction.Create(OpCodes.Ret));
+            }
+
+            if (module.GetTypes().Any(x => x.Name == "OpenSslWrapperBio" && file.Contains("Open")))
+            {
+                filePatched = true;
+                var assemblyIteratorType = module.GetTypes().Where(x => x.Name == "OpenSslWrapperBio").FirstOrDefault();
+                var assemblyIteratorTypeCallMethod = module.GetTypes().Where(x => x.Name == "OpenSslWrapperCertBase").LastOrDefault();
+                if (assemblyIteratorType != null)
                 {
-                    var assemblyIteratorType = module.GetTypes().Where(x => x.Name == "AssemblyIterator").FirstOrDefault();
-                    if (assemblyIteratorType != null)
-                    {
-                        var method = assemblyIteratorType.GetMethods().FirstOrDefault(x => x.Name == "CheckIfSignatureOfSingleAssemblyIsValid");
+                    var method = assemblyIteratorType.GetMethods().First(x => x.Name == "Dispose");
+                    var methodCallMethod = assemblyIteratorTypeCallMethod.GetMethods().Last(x => x.Name.Contains("Dispose"));
 
-                        method.Body.InitLocals = true;
-                        method.Body.Variables.Clear();
-                        method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
-                        method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
-                        method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Byte.MakeArrayType()));
-                        method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Boolean));
-
-                        var ilProcessor = method.Body.GetILProcessor();
-                        var i = Instruction.Create(OpCodes.Ldloc_3);
-                        ilProcessor.Clear();
-                        ilProcessor.Append(Instruction.Create(OpCodes.Nop));
-                        ilProcessor.Append(Instruction.Create(OpCodes.Ldc_I4_1));
-                        ilProcessor.Append(Instruction.Create(OpCodes.Stloc_3));
-                        ilProcessor.Append(Instruction.Create(OpCodes.Br_S, i));
-                        ilProcessor.Append(i);
-                        ilProcessor.Append(Instruction.Create(OpCodes.Ret));
-                    }
-
-                    var internalAssemblyIteratorType = module.GetTypes().Where(x => x.Name == "InternalAssemblyIterator").FirstOrDefault();
-                    if (internalAssemblyIteratorType != null)
-                    {
-                        var method = internalAssemblyIteratorType.GetMethods().FirstOrDefault(x => x.Name == "CheckIfSignatureOfSingleAssemblyIsValid");
-
-                        method.Body.InitLocals = true;
-                        method.Body.Variables.Clear();
-                        method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
-                        method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
-                        method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Byte.MakeArrayType()));
-                        method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Boolean));
-
-                        var ilProcessor = method.Body.GetILProcessor();
-                        var i = Instruction.Create(OpCodes.Ldloc_3);
-                        ilProcessor.Clear();
-                        ilProcessor.Append(Instruction.Create(OpCodes.Nop));
-                        ilProcessor.Append(Instruction.Create(OpCodes.Ldc_I4_1));
-                        ilProcessor.Append(Instruction.Create(OpCodes.Stloc_3));
-                        ilProcessor.Append(Instruction.Create(OpCodes.Br_S, i));
-                        ilProcessor.Append(i);
-                        ilProcessor.Append(Instruction.Create(OpCodes.Ret));
-                    }
-                    var newFile = file.Substring(0, file.Length - 3) + ".patched";
-                    if (File.Exists(newFile))
-                        File.Delete(newFile);
-                    assembly.Write(newFile);
-
-                    patchedFiles.Add(file);
-                    Console.ForegroundColor = ConsoleColor.Green;
-                    Console.WriteLine("Process File: " + file);
-                    Console.WriteLine("--> file was patched...");
-                    Console.ForegroundColor = ConsoleColor.Gray;
+                    method.Body.ExceptionHandlers.Clear();
+                    var ilProcessor = method.Body.GetILProcessor();
+                    ilProcessor.Clear();
+                    ilProcessor.Append(Instruction.Create(OpCodes.Ldarg_0));
+                    ilProcessor.Append(Instruction.Create(OpCodes.Ldarg_1));
+                    ilProcessor.Append(Instruction.Create(OpCodes.Call, methodCallMethod));
+                    ilProcessor.Append(Instruction.Create(OpCodes.Ret));
                 }
-                
-                if (module.GetTypes().Any(x => x.Name == "OpenSslWrapperBio" && file.Contains("Open"))) 
-                {
+            }
 
-                    var assemblyIteratorType = module.GetTypes().Where(x => x.Name == "OpenSslWrapperBio").FirstOrDefault();
-                    var assemblyIteratorTypeCallMethod = module.GetTypes().Where(x => x.Name == "OpenSslWrapperCertBase").LastOrDefault();
-                    if (assemblyIteratorType != null)
-                    {
-                        var method = assemblyIteratorType.GetMethods().FirstOrDefault(x => x.Name == "Dispose");
-                        var methodCallMethod = assemblyIteratorTypeCallMethod.GetMethods().Last(x => x.Name.Contains("Dispose"));
+            if (filePatched)
+            {
+                var newFile = Path.ChangeExtension(file, ".patched");
+                if (File.Exists(newFile))
+                    File.Delete(newFile);
+                assembly.Write(newFile);
 
-
-                        method.Body.ExceptionHandlers.Clear();
-                        var ilProcessor = method.Body.GetILProcessor();
-                        ilProcessor.Clear();
-                        ilProcessor.Append(Instruction.Create(OpCodes.Ldarg_0));
-                        ilProcessor.Append(Instruction.Create(OpCodes.Ldarg_1));
-                        ilProcessor.Append(Instruction.Create(OpCodes.Call,methodCallMethod));
-                        ilProcessor.Append(Instruction.Create(OpCodes.Ret));
-
-
-                    }
-
-                    
-
-                    var newFile = file.Substring(0, file.Length - 3) + ".patched";
-                    if (File.Exists(newFile))
-                        File.Delete(newFile);
-                    assembly.Write(newFile);
-
-                    patchedFiles.Add(file);
-                    Console.ForegroundColor = ConsoleColor.Green;
-                    Console.WriteLine("Process File: " + file);
-                    Console.WriteLine("--> file was patched...");
-                    Console.ForegroundColor = ConsoleColor.Gray;
-                }
+                patchedFiles.Add(file);
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine("\tProcess File: " + file);
+                Console.WriteLine("\t--> file was patched...");
+                Console.ForegroundColor = ConsoleColor.Gray;
             }
         }
         catch (BadImageFormatException)
         {
+            //Console.ForegroundColor = ConsoleColor.Red;
+            //Console.WriteLine("Process File: " + file);
             //Console.WriteLine("--> File is not an Assembly");
+            //Console.ForegroundColor = ConsoleColor.Gray;
         }
         catch (IOException)
         {
+            Console.ForegroundColor = ConsoleColor.Red;
             Console.WriteLine("Process File: " + file);
             Console.WriteLine("--> File is not accessible, this may be a problem if file is needed to be patched");
+            Console.ForegroundColor = ConsoleColor.Gray;
         }
     }
-
-
 }
 
 Console.WriteLine();
-Console.WriteLine();
-
-Console.ForegroundColor = ConsoleColor.Green;
-Console.WriteLine("Patched " + patchedFiles.Count + " files");
-foreach (var file in patchedFiles)
-{
-    Console.WriteLine("Patched: " + file);
-    var backupFile =  file.Substring(0, file.Length - 3) + ".backup";
-    var patchedFile = file.Substring(0, file.Length - 3) + ".patched";
-    if (File.Exists(backupFile))
-    {
-        File.Delete(file);
-    }
-    else
-    {
-        File.Move(file, backupFile);
-    }
-    File.Move(patchedFile, file);
-}
 Console.ForegroundColor = ConsoleColor.Gray;
-Console.WriteLine();
-Console.WriteLine("Finished patching, press Key to exit");
-
+Console.WriteLine("Patched " + patchedFiles.Count + " files");
+Console.Write("Do you confirm you want to overwrite TIA files (Y/N): ");
+if (Console.ReadKey().Key == ConsoleKey.Y)
+{
+    Console.WriteLine();
+    foreach (var file in patchedFiles)
+    {
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine("Patched: " + file);
+        var backupFile = Path.ChangeExtension(file, ".backup");
+        var patchedFile = Path.ChangeExtension(file, ".patched");
+        int backupNum = 1;
+        while (File.Exists(backupFile))
+            backupFile = Path.ChangeExtension(file, $".backup{backupNum}");
+        File.Move(file, backupFile);
+        File.Move(patchedFile, file);
+    }
+    Console.ForegroundColor = ConsoleColor.Gray;
+    Console.WriteLine();
+    Console.WriteLine("Finished patching, press Key to exit");
+}
+else
+{
+    Console.WriteLine();
+    Console.ForegroundColor = ConsoleColor.Red;
+    Console.WriteLine("Patching aborted, press Key to exit");
+    Console.ForegroundColor = ConsoleColor.Gray;
+}
 Console.ReadLine();
+

--- a/TiaArmPatcher/TiaArmPatcher/TiaArmPatcher.csproj
+++ b/TiaArmPatcher/TiaArmPatcher/TiaArmPatcher.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>


### PR DESCRIPTION
Allow for selection of individual / All x86 / All x64 / ALL ALL versions to patch

Unfortunately I don't have an ARM processor to actually test this on.
I have tried not to actually change the IL code mods at all, just consolidated the two iterator paths to be unified.

It would be great if someone could test this on some of the other TIA Portal versions available.
I've got V12->V19 installed in my Windows 11 VM running on Windows 11 base (Intel processor).

I dropped the .NET version to v5 since v7 is not yet a TIA requirement, whilst v5 is for certain TIA versions (so should be installed if TIA Portal is installed).